### PR TITLE
Separate version from coodinate header

### DIFF
--- a/src/main/kotlin/com/jakewharton/kmpmt/dependencyGraph.kt
+++ b/src/main/kotlin/com/jakewharton/kmpmt/dependencyGraph.kt
@@ -8,48 +8,65 @@ import org.gradle.api.artifacts.result.ResolvedComponentResult
 import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.gradle.api.logging.Logger
 
-internal data class DependencyCoordinates(
+internal data class DependencyCoordinate(
 	val group: String,
 	val artifact: String,
-	val version: String,
 ) : Serializable,
-	Comparable<DependencyCoordinates> {
-	override fun toString() = "$group:$artifact:$version"
-	fun moduleCoordinate() = "$this@module"
-	override fun compareTo(other: DependencyCoordinates) = comparator.compare(this, other)
+	Comparable<DependencyCoordinate> {
+	override fun toString() = "$group:$artifact"
+	override fun compareTo(other: DependencyCoordinate) = comparator.compare(this, other)
 
 	private companion object {
 		val comparator = compareBy(
-			DependencyCoordinates::group,
-			DependencyCoordinates::artifact,
-			DependencyCoordinates::version,
+			DependencyCoordinate::group,
+			DependencyCoordinate::artifact,
 		)
 	}
 }
 
-internal fun loadDependencyCoordinates(
+internal data class VersionedDependency(
+	val coordinate: DependencyCoordinate,
+	val version: String,
+) : Serializable,
+	Comparable<VersionedDependency> {
+	override fun toString() = "$coordinate:$version"
+	fun moduleCoordinate() = "$this@module"
+	override fun compareTo(other: VersionedDependency) = comparator.compare(this, other)
+
+	private companion object {
+		val comparator = compareBy(
+			VersionedDependency::coordinate,
+			VersionedDependency::version,
+		)
+	}
+}
+
+internal fun loadVersionedDependencies(
 	logger: Logger,
 	root: ResolvedComponentResult,
 ): DependencyResolutionResult {
 	val warnings = mutableListOf<String>()
 
-	val coordinates = mutableSetOf<DependencyCoordinates>()
-	loadDependencyCoordinates(logger, root, coordinates, mutableSetOf(), depth = 1)
+	val coordinates = mutableSetOf<VersionedDependency>()
+	loadVersionedDependencies(logger, root, coordinates, mutableSetOf(), depth = 1)
 
 	return DependencyResolutionResult(coordinates, warnings)
 }
 
 internal data class DependencyResolutionResult(
-	val coordinates: Set<DependencyCoordinates>,
+	val versionedCoordinates: Set<VersionedDependency>,
 	val configWarnings: List<String>,
 )
 
-internal fun ModuleComponentIdentifier.toDependencyCoordinates() = DependencyCoordinates(group, module, version)
+internal fun ModuleComponentIdentifier.toVersionedDependency() = VersionedDependency(
+	coordinate = DependencyCoordinate(group, module),
+	version = version,
+)
 
-private fun loadDependencyCoordinates(
+private fun loadVersionedDependencies(
 	logger: Logger,
 	root: ResolvedComponentResult,
-	destination: MutableSet<DependencyCoordinates>,
+	destination: MutableSet<VersionedDependency>,
 	seen: MutableSet<ComponentIdentifier>,
 	depth: Int,
 ) {
@@ -67,7 +84,7 @@ private fun loadDependencyCoordinates(
 				// Assuming flat-dir repository dependency, do nothing.
 				ignoreSuffix = " ignoring because flat-dir repository artifact has no metadata"
 			} else {
-				destination += id.toDependencyCoordinates()
+				destination += id.toVersionedDependency()
 			}
 		}
 
@@ -92,7 +109,7 @@ private fun loadDependencyCoordinates(
 		if (dependency is ResolvedDependencyResult) {
 			val selected = dependency.selected
 			if (seen.add(selected.id)) {
-				loadDependencyCoordinates(
+				loadVersionedDependencies(
 					logger,
 					selected,
 					destination,

--- a/src/main/kotlin/com/jakewharton/kmpmt/plugin.kt
+++ b/src/main/kotlin/com/jakewharton/kmpmt/plugin.kt
@@ -8,7 +8,7 @@ import org.gradle.language.base.plugins.LifecycleBasePlugin.VERIFICATION_GROUP
 import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation.Companion.MAIN_COMPILATION_NAME
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinMultiplatformPlugin.Companion.METADATA_TARGET_NAME
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinMetadataTarget.Companion.METADATA_TARGET_NAME
 
 @Suppress("unused") // Instantiated reflectively by Gradle.
 public class MissingTargetsPlugin : Plugin<Project> {

--- a/src/main/kotlin/com/jakewharton/kmpmt/task.kt
+++ b/src/main/kotlin/com/jakewharton/kmpmt/task.kt
@@ -42,7 +42,7 @@ import org.jetbrains.kotlin.konan.target.KonanTarget.Companion.predefinedTargets
 @CacheableTask
 public abstract class MissingTargetsTask : DefaultTask() {
 	@get:Input
-	internal abstract val coordinateToModuleJson: MapProperty<DependencyCoordinates, String>
+	internal abstract val dependenciesToModuleJson: MapProperty<VersionedDependency, String>
 
 	@get:Input
 	internal abstract val projectName: Property<String>
@@ -63,8 +63,8 @@ public abstract class MissingTargetsTask : DefaultTask() {
 
 		val currentTargets = sourceSetTargets.get().toSortedSet()
 
-		val coordinateToTargets = coordinateToModuleJson.get()
-			.filterKeys { coordinate ->
+		val dependenciesToTargets = dependenciesToModuleJson.get()
+			.filterKeys { (coordinate) ->
 				// The common stdlib has empty module metadata and is a dependency of the regular stdlib.
 				coordinate.group != "org.jetbrains.kotlin" || coordinate.artifact != "kotlin-stdlib-common"
 			}
@@ -84,14 +84,14 @@ public abstract class MissingTargetsTask : DefaultTask() {
 			}
 			.toSortedMap()
 
-		val targetsToMissingCoordinates = coordinateToTargets.values
+		val targetsToMissingCoordinates = dependenciesToTargets.values
 			.fold(emptySet(), Set<String>::union)
 			.associateWith { seenTarget ->
-				coordinateToTargets.filterValues { seenTarget !in it }.keys
+				dependenciesToTargets.filterValues { seenTarget !in it }.keys
 			}
 			.filterValues(Set<*>::isNotEmpty)
 
-		val possibleTargets = coordinateToTargets.values
+		val possibleTargets = dependenciesToTargets.values
 			.reduceOrNull(Set<String>::intersect)
 			?: throw IllegalStateException("Project has zero dependencies (not even the stdlib)")
 
@@ -104,9 +104,9 @@ public abstract class MissingTargetsTask : DefaultTask() {
 					append(": ")
 					appendLine(currentTargets)
 
-					if (coordinateToTargets.isNotEmpty()) {
+					if (dependenciesToTargets.isNotEmpty()) {
 						appendLine()
-						for ((coordinate, coordinateTargets) in coordinateToTargets) {
+						for ((coordinate, coordinateTargets) in dependenciesToTargets) {
 							append(coordinate)
 							append(": ")
 							appendLine(coordinateTargets)
@@ -182,15 +182,19 @@ public abstract class MissingTargetsTask : DefaultTask() {
 				appendLine()
 				appendLine()
 				appendLine("# Supported targets by dependency")
-				if (coordinateToTargets.isEmpty()) {
+				if (dependenciesToTargets.isEmpty()) {
 					appendLine()
 					appendLine("None!")
 				} else {
-					for ((coordinate, coordinateTargets) in coordinateToTargets) {
+					for ((dependency, coordinateTargets) in dependenciesToTargets) {
 						appendLine()
 						append("## `")
-						append(coordinate)
+						append(dependency.coordinate)
 						appendLine('`')
+						appendLine()
+						append("Current version: ")
+						appendLine(dependency.version)
+						appendLine()
 						for (target in coordinateTargets) {
 							append("- `")
 							append(target)
@@ -213,7 +217,7 @@ public abstract class MissingTargetsTask : DefaultTask() {
 		}
 	}
 
-	private fun extractEffectiveTargets(coordinates: DependencyCoordinates, metadata: GradleModuleMetadata) = buildSet {
+	private fun extractEffectiveTargets(coordinates: VersionedDependency, metadata: GradleModuleMetadata) = buildSet {
 		for (variant in metadata.variants) {
 			if (variant.attributes.gradleDocsType != null) continue
 			if (variant.attributes.gradleUsage != "kotlin-api" && variant.attributes.gradleUsage != "java-api") continue
@@ -225,7 +229,7 @@ public abstract class MissingTargetsTask : DefaultTask() {
 				}
 
 				"native" -> {
-					if (coordinates.group == "org.jetbrains.kotlin" && coordinates.artifact == "kotlin-stdlib") {
+					if (coordinates.coordinate.group == "org.jetbrains.kotlin" && coordinates.coordinate.artifact == "kotlin-stdlib") {
 						// The stdlib does not have proper native targets in its module metadata because it's managed
 						// by the Kotlin Gradle plugin / Kotlin native compiler. Instead, ask the Kotlin Gradle plugin
 						// for its set of supported, non-deprecated targets.
@@ -266,28 +270,28 @@ public abstract class MissingTargetsTask : DefaultTask() {
 		val moduleJsons = configuration
 			.flatMap { it.incoming.resolutionResult.rootComponent }
 			.map { root ->
-				val directDependencies = loadDependencyCoordinates(
+				val directDependencies = loadVersionedDependencies(
 					logger,
 					root,
 				)
-				val moduleFiles = directDependencies.coordinates.fetchModuleFiles(
+				val moduleFiles = directDependencies.versionedCoordinates.fetchModuleFiles(
 					root.variants,
 					dependencies,
 					configurations,
 				)
 				moduleFiles.associate {
-					it.dependencyCoordinates to it.moduleFile.readText()
+					it.dependency to it.moduleFile.readText()
 				}
 			}
 
-		this.coordinateToModuleJson.set(moduleJsons)
+		this.dependenciesToModuleJson.set(moduleJsons)
 	}
 
-	private fun Set<DependencyCoordinates>.fetchModuleFiles(
+	private fun Set<VersionedDependency>.fetchModuleFiles(
 		variants: List<ResolvedVariantResult>,
 		dependencies: DependencyHandler,
 		configurations: ConfigurationContainer,
-	): List<DependencyCoordinatesWithModuleFile> {
+	): List<DependencyWithModuleFile> {
 		val moduleDependencies = map {
 			dependencies.create(it.moduleCoordinate())
 		}.toTypedArray()
@@ -307,17 +311,17 @@ public abstract class MissingTargetsTask : DefaultTask() {
 		val withoutVariants = configurations.detachedConfiguration(*moduleDependencies).artifacts()
 
 		return (withVariants + withoutVariants).mapNotNull {
-			val coordinates = (it.id.componentIdentifier as ModuleComponentIdentifier).toDependencyCoordinates()
+			val coordinates = (it.id.componentIdentifier as ModuleComponentIdentifier).toVersionedDependency()
 			try {
-				DependencyCoordinatesWithModuleFile(coordinates, it.file)
-			} catch (e: GradleException) {
+				DependencyWithModuleFile(coordinates, it.file)
+			} catch (_: GradleException) {
 				null
 			}
-		}.distinctBy { it.dependencyCoordinates }
+		}.distinctBy { it.dependency }
 	}
 
-	private data class DependencyCoordinatesWithModuleFile(
-		val dependencyCoordinates: DependencyCoordinates,
+	private data class DependencyWithModuleFile(
+		val dependency: VersionedDependency,
 		val moduleFile: File,
 	)
 

--- a/src/test/fixtures/first/expected/build/reports/kmp-missing-targets/commonMain.md
+++ b/src/test/fixtures/first/expected/build/reports/kmp-missing-targets/commonMain.md
@@ -39,7 +39,10 @@
 
 # Supported targets by dependency
 
-## `org.jetbrains.kotlin:kotlin-stdlib:2.1.0`
+## `org.jetbrains.kotlin:kotlin-stdlib`
+
+Current version: 2.1.0
+
 - `androidArm32`
 - `androidArm64`
 - `androidX64`
@@ -65,7 +68,10 @@
 - `watchosSimulatorArm64`
 - `watchosX64`
 
-## `org.jetbrains.kotlinx:atomicfu:0.23.1`
+## `org.jetbrains.kotlinx:atomicfu`
+
+Current version: 0.23.1
+
 - `androidArm32`
 - `androidArm64`
 - `androidX64`
@@ -91,7 +97,10 @@
 - `watchosSimulatorArm64`
 - `watchosX64`
 
-## `org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0`
+## `org.jetbrains.kotlinx:kotlinx-coroutines-core`
+
+Current version: 1.8.0
+
 - `androidArm32`
 - `androidArm64`
 - `androidX64`


### PR DESCRIPTION
This will allow linking to the header's anchor without worrying about it changing over time.

Before:
```
## `org.jetbrains.kotlinx:atomicfu:0.23.1`

- `androidArm32`
- `androidArm64`
```

> ## `org.jetbrains.kotlinx:atomicfu:0.23.1`
>
> - `androidArm32`
> - `androidArm64`

After:
```
## `org.jetbrains.kotlinx:atomicfu`

Current version: 0.23.1

- `androidArm32`
- `androidArm64`
```

> ## `org.jetbrains.kotlinx:atomicfu`
>
> Current version: 0.23.1
>
> - `androidArm32`
> - `androidArm64`