### PR TITLE
Use Kotlin-standard target names always

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changed:
 
 Fixed:
 - Correctly match native Android targets. They currently are named slightly different from the DSL, but it should still be relatively clear.
+- Use the Kotlin-standard name (not any user-supplied name) when parsing project targets.
 
 
 ## [0.1.0] - 2024-12-30

--- a/src/main/kotlin/com/jakewharton/kmpmt/MissingTargetsPlugin.kt
+++ b/src/main/kotlin/com/jakewharton/kmpmt/MissingTargetsPlugin.kt
@@ -9,7 +9,11 @@ import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation.Companion.MAIN_COMPILATION_NAME
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.gradle.targets.js.KotlinWasmTargetType
+import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrTarget
+import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
 
 // HEY! If you update the minimum-supported Gradle version check JVM and Kotlin API target in build.gradle.
 private val minimumGradleVersion = GradleVersion.version("8.0")
@@ -67,8 +71,14 @@ public class MissingTargetsPlugin : Plugin<Project> {
 			} else {
 				val name = when (target) {
 					is KotlinNativeTarget -> target.konanTarget.name.nativeTargetNameToCamelCase()
-					// TODO Name is the wrong thing to use here since it can be customized.
-					else -> target.name
+					is KotlinJvmTarget -> "jvm"
+					is KotlinAndroidTarget -> "androidTarget"
+					is KotlinJsIrTarget -> when (target.wasmTargetType) {
+						null -> "js"
+						KotlinWasmTargetType.WASI -> "wasmWasi"
+						KotlinWasmTargetType.JS -> "wasmJs"
+					}
+					else -> error("Unknown target $target (${target::class.java})")
 				}
 				missingTargetsTask.configure {
 					it.sourceSetTargets.add(name)

--- a/src/main/kotlin/com/jakewharton/kmpmt/util.kt
+++ b/src/main/kotlin/com/jakewharton/kmpmt/util.kt
@@ -16,7 +16,11 @@ internal fun String.nativeTargetNameToCamelCase(): String {
 		.withIndex()
 		.joinToString("") { (index, value) ->
 			if (index == 0) {
-				value
+				if (value == "android") {
+					"androidNative"
+				} else {
+					value
+				}
 			} else {
 				value.replaceFirstChar(Char::uppercase)
 			}

--- a/src/test/fixtures/available-targets-some/expected/build/reports/kmp-missing-targets.md
+++ b/src/test/fixtures/available-targets-some/expected/build/reports/kmp-missing-targets.md
@@ -6,10 +6,10 @@
 - `linuxX64`
 
 ## Available targets
-- `androidArm32`
-- `androidArm64`
-- `androidX64`
-- `androidX86`
+- `androidNativeArm32`
+- `androidNativeArm64`
+- `androidNativeX64`
+- `androidNativeX86`
 - `iosArm64`
 - `iosSimulatorArm64`
 - `iosX64`
@@ -43,10 +43,10 @@
 
 Current version: 2.1.0
 
-- `androidArm32`
-- `androidArm64`
-- `androidX64`
-- `androidX86`
+- `androidNativeArm32`
+- `androidNativeArm64`
+- `androidNativeX64`
+- `androidNativeX86`
 - `iosArm64`
 - `iosSimulatorArm64`
 - `iosX64`
@@ -72,10 +72,10 @@ Current version: 2.1.0
 
 Current version: 0.23.1
 
-- `androidArm32`
-- `androidArm64`
-- `androidX64`
-- `androidX86`
+- `androidNativeArm32`
+- `androidNativeArm64`
+- `androidNativeX64`
+- `androidNativeX86`
 - `iosArm64`
 - `iosSimulatorArm64`
 - `iosX64`
@@ -101,10 +101,10 @@ Current version: 0.23.1
 
 Current version: 1.8.0
 
-- `androidArm32`
-- `androidArm64`
-- `androidX64`
-- `androidX86`
+- `androidNativeArm32`
+- `androidNativeArm64`
+- `androidNativeX64`
+- `androidNativeX86`
 - `iosArm64`
 - `iosSimulatorArm64`
 - `iosX64`

--- a/src/test/fixtures/custom-target-name/build.gradle
+++ b/src/test/fixtures/custom-target-name/build.gradle
@@ -1,0 +1,21 @@
+buildscript {
+  dependencies {
+    classpath "com.jakewharton.kmpmt:kmpmt-gradle-plugin:$kmpmtVersion"
+    classpath libs.kotlin.gradlePlugin
+  }
+
+  repositories {
+    maven {
+      url "file://${rootDir.absolutePath}/../../../../build/localMaven"
+    }
+    mavenCentral()
+  }
+}
+
+apply plugin: 'org.jetbrains.kotlin.multiplatform'
+apply plugin: 'com.jakewharton.kmp-missing-targets'
+
+kotlin {
+  js("frontend").nodejs()
+  jvm("backend")
+}

--- a/src/test/fixtures/custom-target-name/expected/build/reports/kmp-missing-targets.md
+++ b/src/test/fixtures/custom-target-name/expected/build/reports/kmp-missing-targets.md
@@ -1,6 +1,10 @@
-# Project 'available-targets-all'
+# Project 'custom-target-name'
 
 ## Current targets
+- `js`
+- `jvm`
+
+## Available targets
 - `androidNativeArm32`
 - `androidNativeArm64`
 - `androidNativeX64`
@@ -8,8 +12,6 @@
 - `iosArm64`
 - `iosSimulatorArm64`
 - `iosX64`
-- `js`
-- `jvm`
 - `linuxArm64`
 - `linuxX64`
 - `macosArm64`

--- a/src/test/fixtures/custom-target-name/settings.gradle
+++ b/src/test/fixtures/custom-target-name/settings.gradle
@@ -1,0 +1,12 @@
+dependencyResolutionManagement {
+  versionCatalogs {
+    libs {
+      from(files('../../../../gradle/libs.versions.toml'))
+    }
+  }
+
+  repositories {
+    mavenCentral()
+    google()
+  }
+}

--- a/src/test/fixtures/ignored-target-available/expected/build/reports/kmp-missing-targets.md
+++ b/src/test/fixtures/ignored-target-available/expected/build/reports/kmp-missing-targets.md
@@ -6,10 +6,10 @@
 - `linuxX64`
 
 ## Available targets
-- `androidArm32`
-- `androidArm64`
-- `androidX64`
-- `androidX86`
+- `androidNativeArm32`
+- `androidNativeArm64`
+- `androidNativeX64`
+- `androidNativeX86`
 - `iosArm64`
 - `iosSimulatorArm64`
 - `iosX64`
@@ -47,10 +47,10 @@
 
 Current version: 2.1.0
 
-- `androidArm32`
-- `androidArm64`
-- `androidX64`
-- `androidX86`
+- `androidNativeArm32`
+- `androidNativeArm64`
+- `androidNativeX64`
+- `androidNativeX86`
 - `iosArm64`
 - `iosSimulatorArm64`
 - `iosX64`
@@ -76,10 +76,10 @@ Current version: 2.1.0
 
 Current version: 0.23.1
 
-- `androidArm32`
-- `androidArm64`
-- `androidX64`
-- `androidX86`
+- `androidNativeArm32`
+- `androidNativeArm64`
+- `androidNativeX64`
+- `androidNativeX86`
 - `iosArm64`
 - `iosSimulatorArm64`
 - `iosX64`
@@ -105,10 +105,10 @@ Current version: 0.23.1
 
 Current version: 1.8.0
 
-- `androidArm32`
-- `androidArm64`
-- `androidX64`
-- `androidX86`
+- `androidNativeArm32`
+- `androidNativeArm64`
+- `androidNativeX64`
+- `androidNativeX86`
 - `iosArm64`
 - `iosSimulatorArm64`
 - `iosX64`

--- a/src/test/fixtures/ignored-target-unavailable/expected/build/reports/kmp-missing-targets.md
+++ b/src/test/fixtures/ignored-target-unavailable/expected/build/reports/kmp-missing-targets.md
@@ -6,10 +6,10 @@
 - `linuxX64`
 
 ## Available targets
-- `androidArm32`
-- `androidArm64`
-- `androidX64`
-- `androidX86`
+- `androidNativeArm32`
+- `androidNativeArm64`
+- `androidNativeX64`
+- `androidNativeX86`
 - `iosArm64`
 - `iosSimulatorArm64`
 - `iosX64`
@@ -43,10 +43,10 @@
 
 Current version: 2.1.0
 
-- `androidArm32`
-- `androidArm64`
-- `androidX64`
-- `androidX86`
+- `androidNativeArm32`
+- `androidNativeArm64`
+- `androidNativeX64`
+- `androidNativeX86`
 - `iosArm64`
 - `iosSimulatorArm64`
 - `iosX64`
@@ -72,10 +72,10 @@ Current version: 2.1.0
 
 Current version: 0.23.1
 
-- `androidArm32`
-- `androidArm64`
-- `androidX64`
-- `androidX86`
+- `androidNativeArm32`
+- `androidNativeArm64`
+- `androidNativeX64`
+- `androidNativeX86`
 - `iosArm64`
 - `iosSimulatorArm64`
 - `iosX64`
@@ -101,10 +101,10 @@ Current version: 0.23.1
 
 Current version: 1.8.0
 
-- `androidArm32`
-- `androidArm64`
-- `androidX64`
-- `androidX86`
+- `androidNativeArm32`
+- `androidNativeArm64`
+- `androidNativeX64`
+- `androidNativeX86`
 - `iosArm64`
 - `iosSimulatorArm64`
 - `iosX64`

--- a/src/test/kotlin/com/jakewharton/kmpmt/MissingTargetsPluginFixtureTest.kt
+++ b/src/test/kotlin/com/jakewharton/kmpmt/MissingTargetsPluginFixtureTest.kt
@@ -43,6 +43,7 @@ class MissingTargetsPluginFixtureTest {
 	fun failure(
 		@TestParameter(
 			"available-targets-some",
+			"custom-target-name",
 			"ignored-target-available",
 			"ignored-target-unavailable",
 		) fixtureName: String,


### PR DESCRIPTION
---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
