### PR TITLE
Remove toolchain helper

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -5,10 +5,6 @@ pluginManagement {
   }
 }
 
-plugins {
-  id "org.gradle.toolchains.foojay-resolver-convention" version "0.9.0"
-}
-
 dependencyResolutionManagement {
   repositories {
     mavenCentral()


### PR DESCRIPTION
We don't use toolchains. Don't need 'em, don't want 'em.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
