### PR TITLE
Correct attribute type parameter nullability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Changed:
 - In-development snapshots are now published to the Central Portal Snapshots repository at https://central.sonatype.com/repository/maven-snapshots/.
 
 Fixed:
-- Nothing yet!
+- Support usage with Gradle 9.
 
 
 ## [0.1.1] - 2024-12-31

--- a/src/main/kotlin/com/jakewharton/kmpmt/MissingTargetsTask.kt
+++ b/src/main/kotlin/com/jakewharton/kmpmt/MissingTargetsTask.kt
@@ -344,7 +344,7 @@ public abstract class MissingTargetsTask : DefaultTask() {
 					val variantAttrs = variant.attributes
 					for (attrs in variantAttrs.keySet()) {
 						@Suppress("UNCHECKED_CAST")
-						it.attribute(attrs as Attribute<Any?>, variantAttrs.getAttribute(attrs)!!)
+						it.attribute(attrs as Attribute<Any>, variantAttrs.getAttribute(attrs)!!)
 					}
 				}
 			}


### PR DESCRIPTION
This fails to compile with Gradle 9.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
