### PR TITLE
Bump minimum-supported Gradle version to 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Added:
 
 Changed:
 - In-development snapshots are now published to the Central Portal Snapshots repository at https://central.sonatype.com/repository/maven-snapshots/.
+- The minimum-supported Gradle version is now 9.0.
 
 Fixed:
 - Nothing yet!

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
@@ -57,21 +58,18 @@ kotlin {
 	explicitApi()
 }
 
+// Ensure compatibility with old Gradle versions. Keep in sync with MissingTargetsPlugin.kt.
 tasks.withType(KotlinJvmCompile).configureEach {
-	compilerOptions.freeCompilerArgs.add("-Xjvm-default=all")
-
-	// "A JVM version between 8 and 23 is required to execute Gradle."
-	// https://docs.gradle.org/current/userguide/compatibility.html#java_runtime
-	compilerOptions.jvmTarget = JvmTarget.JVM_1_8
-
-	// Ensure compatibility with old Gradle versions. Keep in sync with plugin minimum.
-	// https://docs.gradle.org/current/userguide/compatibility.html#kotlin
-	compilerOptions.apiVersion.set(KotlinVersion.KOTLIN_1_8)
+	compilerOptions {
+		jvmTarget = JvmTarget.JVM_17
+		jvmDefault = JvmDefaultMode.NO_COMPATIBILITY
+		apiVersion = KotlinVersion.KOTLIN_2_2
+		languageVersion = KotlinVersion.KOTLIN_2_2
+	}
 }
-
 tasks.withType(JavaCompile).configureEach { task ->
-	task.sourceCompatibility = '1.8'
-	task.targetCompatibility = '1.8'
+	task.sourceCompatibility = '17'
+	task.targetCompatibility = '17'
 }
 
 tasks.named("test") {

--- a/src/main/kotlin/com/jakewharton/kmpmt/MissingTargetsPlugin.kt
+++ b/src/main/kotlin/com/jakewharton/kmpmt/MissingTargetsPlugin.kt
@@ -16,14 +16,14 @@ import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrTarget
 import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
 
 // HEY! If you update the minimum-supported Gradle version check JVM and Kotlin API target in build.gradle.
-private val minimumGradleVersion = GradleVersion.version("8.0")
+private val minimumGradleVersion = GradleVersion.version("9.0")
 
 @Suppress("unused") // Instantiated reflectively by Gradle.
 public class MissingTargetsPlugin : Plugin<Project> {
 	override fun apply(project: Project) {
 		val gradleVersion = GradleVersion.current()
 		check(gradleVersion >= minimumGradleVersion) {
-			"Plugin requires Gradle ${minimumGradleVersion.version} or later. Found ${gradleVersion.version}"
+			"Plugin requires $minimumGradleVersion or later. Found $gradleVersion"
 		}
 
 		var gotKmp = false


### PR DESCRIPTION
This allows us to use Kotlin 2.2 and Java 17. The forthcoming Kotlin 2.3.0 will no longer support compiling to 1.8, so we must bump.

Closes #117 

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
