### PR TITLE
Validate compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+import compat.patrouille.Severity
 
 buildscript {
 	dependencies {
@@ -11,6 +10,8 @@ buildscript {
 		classpath libs.gradleMavenPublishPlugin
 		classpath libs.spotlessPlugin
 		classpath libs.android.gradlePlugin
+		classpath libs.buildConfigPlugin
+		classpath libs.compatPlugin
 	}
 	repositories {
 		mavenCentral()
@@ -25,6 +26,8 @@ apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka'
 apply plugin: 'com.diffplug.spotless'
 apply plugin: 'com.android.lint'
+apply plugin: 'com.github.gmazzo.buildconfig'
+apply plugin: 'com.gradleup.compat.patrouille'
 
 gradlePlugin {
 	plugins {
@@ -58,23 +61,44 @@ kotlin {
 	explicitApi()
 }
 
-// Ensure compatibility with old Gradle versions. Keep in sync with MissingTargetsPlugin.kt.
-tasks.withType(KotlinJvmCompile).configureEach {
-	compilerOptions {
-		jvmTarget = JvmTarget.JVM_17
-		jvmDefault = JvmDefaultMode.NO_COMPATIBILITY
-		apiVersion = KotlinVersion.KOTLIN_2_2
-		languageVersion = KotlinVersion.KOTLIN_2_2
+// HEY! If you update the minimum-supported Gradle version check to see if the Kotlin language version or
+// Java targets below can be bumped. See https://docs.gradle.org/current/userguide/compatibility.html.
+def minimumGradleVersion = '9.0'
+configurations.apiElements {
+	attributes {
+		attribute(
+			GradlePluginApiVersion.GRADLE_PLUGIN_API_VERSION_ATTRIBUTE,
+			objects.named(GradlePluginApiVersion, minimumGradleVersion),
+		)
 	}
 }
-tasks.withType(JavaCompile).configureEach { task ->
-	task.sourceCompatibility = '17'
-	task.targetCompatibility = '17'
+
+compatPatrouille {
+	java(17)
+	kotlin('2.2.0')
+	checkApiDependencies(Severity.ERROR)
+	checkRuntimeDependencies(Severity.ERROR)
+}
+
+buildConfig {
+	sourceSets.getByName('test') {
+		useKotlinOutput {
+			packageName = 'com.jakewharton.kmpmt'
+			topLevelConstants = true
+		}
+		buildConfigField(String, 'MINIMUM_GRADLE_VERSION', minimumGradleVersion)
+		buildConfigField(String, "KMPMT_VERSION", VERSION_NAME)
+	}
+}
+
+tasks.withType(KotlinJvmCompile).configureEach {
+	compilerOptions {
+		jvmDefault = JvmDefaultMode.NO_COMPATIBILITY
+	}
 }
 
 tasks.named("test") {
 	dependsOn(':publishAllPublicationsToTestingRepository')
-	systemProperty('kmpmtVersion', VERSION_NAME)
 	inputs.dir('src/test/fixtures')
 
 	testLogging {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,8 @@ kotlin-serializationPlugin = { module = "org.jetbrains.kotlin:kotlin-serializati
 dokkaPlugin = "org.jetbrains.dokka:dokka-gradle-plugin:2.1.0"
 spotlessPlugin = "com.diffplug.spotless:spotless-plugin-gradle:8.0.0"
 gradleMavenPublishPlugin = "com.vanniktech:gradle-maven-publish-plugin:0.34.0"
+buildConfigPlugin = "com.github.gmazzo.buildconfig:plugin:5.7.0"
+compatPlugin = "com.gradleup.compat.patrouille:compat-patrouille-gradle-plugin:0.1.0"
 
 kotlinx-serialization = "org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0"
 

--- a/src/test/kotlin/com/jakewharton/kmpmt/MissingTargetsPluginFixtureTest.kt
+++ b/src/test/kotlin/com/jakewharton/kmpmt/MissingTargetsPluginFixtureTest.kt
@@ -27,7 +27,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(TestParameterInjector::class)
-class MissingTargetsPluginFixtureTest {
+class MissingTargetsPluginFixtureTest(
+	@param:TestParameter(LATEST_GRADLE_VERSION, MINIMUM_GRADLE_VERSION)
+	private val gradleVersion: String,
+) {
 	@Test
 	fun success(
 		@TestParameter(
@@ -95,6 +98,11 @@ class MissingTargetsPluginFixtureTest {
 			androidSdkFile.copyTo(File(fixtureDir, "local.properties"), overwrite = true)
 		}
 		return GradleRunner.create()
+			.apply {
+				if (gradleVersion != LATEST_GRADLE_VERSION) {
+					withGradleVersion(gradleVersion)
+				}
+			}
 			.withProjectDir(fixtureDir)
 			.withDebug(true) // Run in-process
 			.withArguments(
@@ -104,7 +112,8 @@ class MissingTargetsPluginFixtureTest {
 				"--continue",
 				"--configuration-cache",
 				"--no-build-cache",
-				versionProperty,
+				VERSION_PROPERTY,
+				VALIDATE_KOTLIN_METADATA,
 			)
 			.forwardOutput()
 	}
@@ -128,4 +137,6 @@ class MissingTargetsPluginFixtureTest {
 }
 
 private val fixturesDir = File("src/test/fixtures")
-private val versionProperty = "-PkmpmtVersion=${System.getProperty("kmpmtVersion")!!}"
+private const val VERSION_PROPERTY = "-PkmpmtVersion=$KMPMT_VERSION"
+private const val LATEST_GRADLE_VERSION = "latest"
+private const val VALIDATE_KOTLIN_METADATA = "-Porg.gradle.kotlin.dsl.skipMetadataVersionCheck=false"


### PR DESCRIPTION
Empirically by varying the test suite across the supported Gradle range and imperatively through a Gradle plugin that walks the transitive classpath.

https://github.com/JakeWharton/multiproject-refactors/issues/1

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
