### PR TITLE
Remove explicit Gradle API dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,6 @@ tasks.named("validatePlugins") {
 }
 
 dependencies {
-	compileOnly gradleApi()
 	implementation libs.kotlin.gradlePlugin
 	implementation libs.kotlinx.serialization
 


### PR DESCRIPTION
The java-gradle-plugin plugin applies it automatically.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
